### PR TITLE
fix: React Native 0.77.3 compatibility updates

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,13 +28,11 @@ def getExtOrIntegerDefault(name) {
 
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
-  buildToolsVersion getExtOrDefault('buildToolsVersion')
+  
   defaultConfig {
     minSdkVersion 23
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
-    versionCode 1
-    versionName "1.0"
-
+    namespace "com.reactnativeespidfprovisioning"
   }
 
   buildTypes {
@@ -129,7 +127,7 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation 'org.greenrobot:eventbus:3.1.1'
-  implementation 'com.github.espressif:esp-idf-provisioning-android:lib-2.0.13'
+  implementation 'com.github.espressif:esp-idf-provisioning-android:lib-2.1.2'
   implementation 'com.google.crypto.tink:tink-android:1.1.0'
   implementation 'com.google.protobuf:protobuf-javalite:3.14.0'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactnativeespidfprovisioning">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <!-- BLUETOOTH_ADMIN and BLUETOOTH permission are required to perform the ESP-IDF-BLE scan-->

--- a/android/src/main/java/com/reactnativeespidfprovisioning/EspIdfProvisioningModule.kt
+++ b/android/src/main/java/com/reactnativeespidfprovisioning/EspIdfProvisioningModule.kt
@@ -75,7 +75,7 @@ class EspIdfProvisioningModule(reactContext: ReactApplicationContext) : ReactCon
       }
 
       override fun onFailure(p0: Exception?) {
-        promise.reject(p0.toString())
+        promise.reject(p0 as? Throwable ?: RuntimeException(p0?.message ?: "Connection failed", p0))
       }
     });
   }
@@ -183,7 +183,7 @@ class EspIdfProvisioningModule(reactContext: ReactApplicationContext) : ReactCon
       }
 
       override fun onWiFiScanFailed(p0: java.lang.Exception?) {
-        promise.reject(p0)
+        promise.reject(p0 as? Throwable ?: RuntimeException("WiFi scan failed", p0))
       }
     })
   }
@@ -197,7 +197,7 @@ class EspIdfProvisioningModule(reactContext: ReactApplicationContext) : ReactCon
           Log.e("ESPProvisioning", "provision-wifiConfigApplyFailed"+p0.toString());
           device.disconnectDevice()
           // device.refreshServicesOfBleDevice() //instead of disconnect just for test
-          promise.reject(p0.toString())
+          promise.reject(p0 as? Throwable ?: RuntimeException(p0?.message ?: "Provision failed", p0))
         }
 
         override fun wifiConfigApplied() {
@@ -208,7 +208,7 @@ class EspIdfProvisioningModule(reactContext: ReactApplicationContext) : ReactCon
           device.disconnectDevice()
           // device.refreshServicesOfBleDevice() //instead of disconnect just for test
           Log.e("ESPProvisioning", "provision-onProvisioningFailed"+p0.toString());
-          promise.reject(p0.toString())
+          promise.reject(p0 as? Throwable ?: RuntimeException(p0?.message ?: "Provision failed", p0))
         }
 
         override fun deviceProvisioningSuccess() {
@@ -219,21 +219,22 @@ class EspIdfProvisioningModule(reactContext: ReactApplicationContext) : ReactCon
         override fun createSessionFailed(p0: Exception?) {
           //here disconnect is not needed, in the SessionError catch disconnect call is already presented
           Log.e("ESPProvisioning", "provision-createSessionFailed"+p0.toString());
-          promise.reject(p0.toString())
+          promise.reject(p0 as? Throwable ?: RuntimeException(p0?.message ?: "Provision failed", p0))
         }
 
         override fun wifiConfigFailed(p0: Exception?) {
           device.disconnectDevice()
           // device.refreshServicesOfBleDevice() //instead of disconnect just for test
           Log.e("ESPProvisioning", "provision-wifiConfigFailed"+p0.toString());
-          promise.reject(p0.toString())
+          promise.reject(p0 as? Throwable ?: RuntimeException(p0?.message ?: "Provision failed", p0))
         }
 
         override fun provisioningFailedFromDevice(p0: ESPConstants.ProvisionFailureReason?) {
           device.disconnectDevice()
           // device.refreshServicesOfBleDevice() //instead of disconnect just for test
-          Log.e("ESPProvisioning", "provision-provisioningFailedFromDevice"+p0.toString());
-          promise.reject(p0.toString())
+          val errorMessage = p0?.name ?: "Unknown provision failure"
+          Log.e("ESPProvisioning", "provision-provisioningFailedFromDevice: $errorMessage");
+          promise.reject("PROVISION_ERROR", "Provisioning failed: $errorMessage")
         }
 
         override fun wifiConfigSent() {

--- a/android/src/main/java/com/reactnativeespidfprovisioning/EspIdfProvisioningPackage.kt
+++ b/android/src/main/java/com/reactnativeespidfprovisioning/EspIdfProvisioningPackage.kt
@@ -10,6 +10,10 @@ import com.facebook.react.uimanager.ViewManager
 import com.facebook.react.bridge.JavaScriptModule
 
 class EspIdfProvisioningPackage : ReactPackage {
+    override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
+        return if (name == "EspIdfProvisioning") EspIdfProvisioningModule(reactContext) else null
+    }
+
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
         return Arrays.asList<NativeModule>(EspIdfProvisioningModule(reactContext))
     }

--- a/ios/EspIdfProvisioning.m
+++ b/ios/EspIdfProvisioning.m
@@ -1,5 +1,10 @@
+#ifdef RCT_NEW_ARCH_ENABLED
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
+#else
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+#endif
 
 @interface RCT_EXTERN_MODULE(EspIdfProvisioning, RCTEventEmitter)
 

--- a/ios/EspIdfProvisioning.swift
+++ b/ios/EspIdfProvisioning.swift
@@ -23,8 +23,27 @@ public enum ProvisionEventNames: String {
 @objc(EspIdfProvisioning)
 class EspIdfProvisioning: RCTEventEmitter {
     private var security: ESPSecurity = .secure
+    private var hasListeners = false
 
     var bleDevices:[ESPDevice]?
+    
+    @objc override static func moduleName() -> String! {
+        return "EspIdfProvisioning"
+    }
+    
+    override func startObserving() {
+        hasListeners = true
+    }
+    
+    override func stopObserving() {
+        hasListeners = false
+    }
+    
+    override func sendEvent(withName name: String!, body: Any!) {
+        if hasListeners {
+            super.sendEvent(withName: name, body: body)
+        }
+    }
 
     @objc(createDevice:devicePassword:deviceProofOfPossession:successCallback:)
     func createDevice(_ deviceName: String, devicePassword: String, deviceProofOfPossession: String, successCallback: @escaping RCTResponseSenderBlock) -> Void {


### PR DESCRIPTION
- Android: Remove deprecated buildToolsVersion
- Android: Add namespace to build.gradle for AGP 8+
- Android: Update ESP library to lib-2.1.2
- Android: Remove package attribute from AndroidManifest.xml
- Android: Fix promise.reject() calls to use Throwable type
- Android: Add getModule() method to EspIdfProvisioningPackage
- iOS: Add conditional imports for New Architecture support
- iOS: Add moduleName() static method
- iOS: Implement listener tracking for event emitter

These changes ensure compatibility with React Native 0.77.3 and the latest Android Gradle Plugin requirements.